### PR TITLE
fix: correção no texto no Liskov Substitution Principle

### DIFF
--- a/en/docs/3-lsp.md
+++ b/en/docs/3-lsp.md
@@ -99,7 +99,7 @@ interface OAuthContract {
     public function getAuthenticatedUser(string $accessToken): array;
 }
 
-class SpotifyService extends OAuthContract {
+class SpotifyService implements OAuthContract {
 
     public function auth(string $code): bool
     {
@@ -112,7 +112,7 @@ class SpotifyService extends OAuthContract {
     }
 }
 
-class TwitchService extends OAuthContract {
+class TwitchService implements OAuthContract {
 
     public function auth(string $code): bool
     {
@@ -183,7 +183,7 @@ interface OAuthContract {
     public function getAuthenticatedUser(string $accessToken): array;
 }
 
-class SpotifyService extends OAuthContract {
+class SpotifyService implements OAuthContract {
 
     public function auth(string $code): bool
     {
@@ -201,7 +201,7 @@ class SpotifyService extends OAuthContract {
     }
 }
 
-class TwitchService extends OAuthContract {
+class TwitchService implements OAuthContract {
 
     public function auth(string $code): bool
     {

--- a/pt_BR/docs/3-lsp.md
+++ b/pt_BR/docs/3-lsp.md
@@ -98,7 +98,7 @@ interface OAuthContract {
     public function getAuthenticatedUser(string $accessToken): array;
 }
 
-class SpotifyService extends OAuthContract {
+class SpotifyService implements OAuthContract {
 
     public function auth(string $code): bool
     {
@@ -111,7 +111,7 @@ class SpotifyService extends OAuthContract {
     }
 }
 
-class TwitchService extends OAuthContract {
+class TwitchService implements OAuthContract {
 
     public function auth(string $code): bool
     {
@@ -183,7 +183,7 @@ interface OAuthContract {
     public function getAuthenticatedUser(string $accessToken): array;
 }
 
-class SpotifyService extends OAuthContract {
+class SpotifyService implements OAuthContract {
 
     public function auth(string $code): bool
     {
@@ -201,7 +201,7 @@ class SpotifyService extends OAuthContract {
     }
 }
 
-class TwitchService extends OAuthContract {
+class TwitchService implements OAuthContract {
 
     public function auth(string $code): bool
     {


### PR DESCRIPTION
No texto de `Liskov Substitution Principle` os exemplos estão utilizando `extends` para as interfaces, sendo que uma interface não é extendida e sim implementada. Fiz a alteração. 

Jeito que estava 
```php 
class SpotifyService extends OAuthContract 
{

}
```

Alteração
```php 
class SpotifyService implements OAuthContract 
{

}
```

Outro ponto também, acredito que o LSP não utiliza interface mas sim Classes com assinaturas simples, acredito que valha a pena dar uma olhada se utiliza Interface ou Classes. 

Realmente estou estudando este assunto e notei esses pontos!

Qualquer dúvida podemos discutir no PR :) 
